### PR TITLE
Total card count is actually 370. Missing 20 cards.

### DIFF
--- a/get-keyforgedata.ps1
+++ b/get-keyforgedata.ps1
@@ -2,7 +2,7 @@ param(
     #I believe the page size is 30 max
     $pagesize = 25,
     $search = "",
-    $totalCards = 350,
+    $totalCards = 370,
     $totalHouses = 7
 )
 $Url = "https://www.keyforgegame.com/api/decks/?page={0}&page_size={1}&search={2}&links=cards" -f "{0}", $pagesize, $search


### PR DESCRIPTION
Also your method might be flawed, since it factors in Maverick cards which don't count towards the 370 total count. 